### PR TITLE
CAN task proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Template to create FreeRTOS tasks using the team's middleware
 ## How to change DevBoard
 
 1. At the moment you clone the repo, modify the branch for the `robotConfig` repo.
+        1. This will Change the defines on the `Makefile`
 1. Change the OwlDefines variables at `.vscode/c_cpp_properties.json`
 
 ## Compile:
@@ -51,12 +52,6 @@ arm-none-eabi-gcc -c -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard 
 If you were to change the C/C++ standard used, remember to change it in the `IntelliSense`, `makefile`, and `c_cpp_properties.json`
 
 For more [formatting options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) see the link.
-### Make for other STM32 boards:
-
-TODO: 
-* Change the configuration on `c_cpp_properties.json`
-* Change the defines on the `Makefile`
-* Edit owlware to automatically include the correct library on each module
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Template to create FreeRTOS tasks using the team's middleware
 
 1. From the project folder call make 
 
-        make
+        make all
     1. You might need to specify the compiler path, in which case use:
         
             make GCC_PATH=/path/2/compiler
@@ -32,6 +32,9 @@ Template to create FreeRTOS tasks using the team's middleware
 1. If your build failed, then you can clean the `build` folder
         
         make clean
+1. If you are encountering problems, and would like to know what is being configured by the makefiles from other projects, try:
+
+        make showRobotConfig showRtosConfig
 
 ### Add a file to be compiled 
 
@@ -54,32 +57,6 @@ TODO:
 * Change the configuration on `c_cpp_properties.json`
 * Change the defines on the `Makefile`
 * Edit owlware to automatically include the correct library on each module
-
-### Running for compile
-
-Currently, we're using `make` as our compilation tool. 
-
-By default, make will build whats specified at first, this is the defacto target.
-
-    make
-
-If you wish to compile any other target, then do:
-
-    make targetName
-
-The syntax is like:
-
-```
-targetName: dependency1
-    compiler -flags [args...]
-```
-
-*Note:* Targets may also be defined as dependencies, thus calling a compilation chain
-
-**FYI:** Make can also execute bash commands, so that's why you'll sometimes see commands being used in the `Makefile`. 
-
-In fact the syntax, for declaring, using, and even storing [variables](https://www.gnu.org/savannah-checkouts/gnu/make/manual/make.html#Reading) is the same!
-
 
 ## Resources
 

--- a/app/inc/CANTask.h
+++ b/app/inc/CANTask.h
@@ -11,11 +11,9 @@
 
 #include "main.h"
 #include "cmsis_os.h"
+#include "semphr.h"
 
 #include "structs.h"
-
-#define PENDING_MESSAGES 1
-#define NO_PENDING_MESSAGES 0
 
 CAN_TxHeaderTypeDef TxHeader;
 CAN_RxHeaderTypeDef RxHeader;
@@ -25,55 +23,73 @@ MotorControlMessage RxData;
 
 uint32_t TxMailbox;
 
-uint8_t hasPendingMessages = 0;
+SemaphoreHandle_t xCANSemaphore;
 
-osThreadId_t CANTaskHandle;
+osThreadId_t CANTxTaskHandle;
 const osThreadAttr_t CANTask_attributes = {
-  .name = "CANTask",
+  .name = "CANTxTask",
+  .stack_size = 128 * 4,
+  .priority = (osPriority_t) osPriorityNormal,
+};
+
+osThreadId_t CANRxTaskHandle;
+const osThreadAttr_t CANTask_attributes = {
+  .name = "CANRxTask",
   .stack_size = 128 * 4,
   .priority = (osPriority_t) osPriorityNormal,
 };
 
 static void MX_CAN_Init(void);
-void StartCANTask(void *argument);
+void StartCANTxTask(void *argument);
+void StartCANRxTask(void *argument);
 
-void StartCANTask(void *argument) {
-  HAL_CAN_Start(&hcan);
-  HAL_CAN_ActivateNotification(&hcan, CAN_IT_RX_FIFO0_MSG_PENDING);
-
+void StartCANTxTask(void *argument) {
   while (1) {
-    if (hasPendingMessages) {
+    // TODO: Implement TX logic
+  }
+}
+
+void StartCANRxTask(void *argument) {
+  while (1) {
+    if (osSemaphoreAcquire(xCANSemaphore, osWaitForever) == osOK) {
       // Send the message to the corresponding node or subsystem
       // TODO: Implement the logic to retrived data from the remote controller
       TxData.vMotor1 = RxData.vMotor1;
       TxData.vMotor2 = RxData.vMotor2;
       TxData.vMotor3 = RxData.vMotor3;
       TxData.vMotor4 = RxData.vMotor4;
+      osSemaphoreAcquire(xCANSemaphore, osWaitForever);
       HAL_CAN_AddTxMessage(&hcan, &TxHeader, TxData, &TxMailbox);
 
-      // Reset the flag
-      hasPendingMessages = NO_PENDING_MESSAGES;
-
-      // Report current data from the CAN bus
-      // TODO: Implement the logic to retrieve data from the CAN bus nodes (chassis and gymbal)
-      TxData.vMotor1 = RxData.vMotor1;
-      TxData.vMotor2 = RxData.vMotor2;
-      TxData.vMotor3 = RxData.vMotor3;
-      TxData.vMotor4 = RxData.vMotor4;
-      HAL_CAN_AddTxMessage(&hcan, &TxHeader, TxData, &TxMailbox);
+      osDelay(100);
     }
   }
 }
 
-void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan) {
-  if (HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, &RxHeader, RxData) != HAL_OK) {
-    // Handle error
-    /* Proposal:
-     * 1. Print an error message through the USART2 peripheral (connects to the ST-Link hence the computer)
-     * 2. Turn on a LED, preferably the red one (LD2) to indicate an error
-     */
+void HAL_CAN_TxMailbox0CompleteCallback(CAN_HandleTypeDef *hcan) {
+  if (hcan->State == HAL_CAN_STATE_READY) {
+    osSemaphoreRelease(xCANSemaphore);
   }
+}
 
-  // Set a flag to indicate that a message has been received
-  hasPendingMessages = PENDING_MESSAGES;
+void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan) {
+  if (hcan->State == HAL_CAN_STATE_READY) {
+    if (HAL_CAN_GetRxMessage(&hcan, CAN_RX_FIFO0, &RxHeader, (uint8_t*) &RxData) != HAL_OK) {
+      // Handle error
+      /* Proposal:
+      * 1. Print an error message through the USART2 peripheral (connects to the ST-Link hence the computer)
+      * 2. Turn on a LED, preferably the red one (LD2) to indicate an error
+      */
+    }
+
+    osSemaphoreRelease(xCANSemaphore);
+  }
+}
+
+void InitCANSemaphore(void) {
+  xCANSemaphore = xSemaphoreCreateBinary();
+
+  if (xCANSemaphore == NULL) {
+    /* Handle error */
+  }
 }

--- a/app/inc/CANTask.h
+++ b/app/inc/CANTask.h
@@ -12,17 +12,10 @@
 #include "main.h"
 #include "cmsis_os.h"
 
+#include "structs.h"
+
 #define PENDING_MESSAGES 1
 #define NO_PENDING_MESSAGES 0
-
-typedef struct {
-  uint8_t vMotor1;
-  uint8_t vMotor2;
-  uint8_t vMotor3;
-  uint8_t vMotor4;
-} MotorControlMessage;
-
-CAN_HandleTypeDef hcan;
 
 CAN_TxHeaderTypeDef TxHeader;
 CAN_RxHeaderTypeDef RxHeader;
@@ -52,7 +45,10 @@ void StartCANTask(void *argument) {
     if (hasPendingMessages) {
       // Send the message to the corresponding node or subsystem
       // TODO: Implement the logic to retrived data from the remote controller
-      MotorControlMessage TxData = {};
+      TxData.vMotor1 = RxData.vMotor1;
+      TxData.vMotor2 = RxData.vMotor2;
+      TxData.vMotor3 = RxData.vMotor3;
+      TxData.vMotor4 = RxData.vMotor4;
       HAL_CAN_AddTxMessage(&hcan, &TxHeader, TxData, &TxMailbox);
 
       // Reset the flag
@@ -60,12 +56,10 @@ void StartCANTask(void *argument) {
 
       // Report current data from the CAN bus
       // TODO: Implement the logic to retrieve data from the CAN bus nodes (chassis and gymbal)
-      MotorControlMessage TxData = {
-        .vMotor1 = RxData.vMotor1,
-        .vMotor2 = RxData.vMotor2,
-        .vMotor3 = RxData.vMotor3,
-        .vMotor4 = RxData.vMotor4,
-      };
+      TxData.vMotor1 = RxData.vMotor1;
+      TxData.vMotor2 = RxData.vMotor2;
+      TxData.vMotor3 = RxData.vMotor3;
+      TxData.vMotor4 = RxData.vMotor4;
       HAL_CAN_AddTxMessage(&hcan, &TxHeader, TxData, &TxMailbox);
     }
   }

--- a/app/inc/CANTask.h
+++ b/app/inc/CANTask.h
@@ -1,0 +1,85 @@
+
+/**
+ * CANTask.c
+ * 
+ * Created on: January 12, 2024
+ *     Author: Erick Daniel Ortiz Cervantes
+ *  Reference: https://www.youtube.com/watch?v=KHNRftBa1Vc
+ */
+
+#pragma once
+
+#include "main.h"
+#include "cmsis_os.h"
+
+#define PENDING_MESSAGES 1
+#define NO_PENDING_MESSAGES 0
+
+typedef struct {
+  uint8_t vMotor1;
+  uint8_t vMotor2;
+  uint8_t vMotor3;
+  uint8_t vMotor4;
+} MotorControlMessage;
+
+CAN_HandleTypeDef hcan;
+
+CAN_TxHeaderTypeDef TxHeader;
+CAN_RxHeaderTypeDef RxHeader;
+
+MotorControlMessage TxData;
+MotorControlMessage RxData;
+
+uint32_t TxMailbox;
+
+uint8_t hasPendingMessages = 0;
+
+osThreadId_t CANTaskHandle;
+const osThreadAttr_t CANTask_attributes = {
+  .name = "CANTask",
+  .stack_size = 128 * 4,
+  .priority = (osPriority_t) osPriorityNormal,
+};
+
+static void MX_CAN_Init(void);
+void StartCANTask(void *argument);
+
+void StartCANTask(void *argument) {
+  HAL_CAN_Start(&hcan);
+  HAL_CAN_ActivateNotification(&hcan, CAN_IT_RX_FIFO0_MSG_PENDING);
+
+  while (1) {
+    if (hasPendingMessages) {
+      // Send the message to the corresponding node or subsystem
+      // TODO: Implement the logic to retrived data from the remote controller
+      MotorControlMessage TxData = {};
+      HAL_CAN_AddTxMessage(&hcan, &TxHeader, TxData, &TxMailbox);
+
+      // Reset the flag
+      hasPendingMessages = NO_PENDING_MESSAGES;
+
+      // Report current data from the CAN bus
+      // TODO: Implement the logic to retrieve data from the CAN bus nodes (chassis and gymbal)
+      MotorControlMessage TxData = {
+        .vMotor1 = RxData.vMotor1,
+        .vMotor2 = RxData.vMotor2,
+        .vMotor3 = RxData.vMotor3,
+        .vMotor4 = RxData.vMotor4,
+      };
+      HAL_CAN_AddTxMessage(&hcan, &TxHeader, TxData, &TxMailbox);
+    }
+  }
+}
+
+void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan) {
+  if (HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, &RxHeader, RxData) != HAL_OK) {
+    // Handle error
+    /* Proposal:
+     * 1. Print an error message through the USART2 peripheral (connects to the ST-Link hence the computer)
+     * 2. Turn on a LED, preferably the red one (LD2) to indicate an error
+     */
+  }
+
+  // Set a flag to indicate that a message has been received
+  hasPendingMessages = PENDING_MESSAGES;
+}

--- a/app/inc/structs.h
+++ b/app/inc/structs.h
@@ -1,0 +1,30 @@
+
+/**
+ * CANTask.c
+ * 
+ * Created on: January 15, 2024
+ *     Author: Erick Daniel Ortiz Cervantes
+ */
+
+#pragma once
+
+#include "main.h"
+
+/**
+ * @brief Represents a subsystem within the CAN bus
+ */
+typedef enum { GIMBALL, CHASSIS } Node;
+
+/**
+ * @brief Represents a CAN bus message
+ * 
+ * @param node: Node or subsystem where the message is sent to
+ * @param vMotorx: Value to set to the speed controller
+ */
+typedef struct {
+    Node node;
+    uint8_t vMotor1;
+    uint8_t vMotor2;
+    uint8_t vMotor3;
+    uint8_t vMotor4;
+} MotorControlMessage;

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -110,7 +110,8 @@ int main(void) {
     osKernelInitialize();
 
     // Create CANTask
-    canTaskHandle = osThreadNew(StartCANTask, NULL, &CANTask_attributes);
+    canTaskHandle = osThreadNew(StartCANTxTask, NULL, &CANTxTask_attributes);
+    canTaskHandle = osThreadNew(StartCANRxTask, NULL, &CANRxTask_attributes);
 
     // Start the RTOS kernel
     osKernelStart();
@@ -188,6 +189,10 @@ static void MX_CAN_Init(void) {
     TxHeader.RTR = CAN_RTR_DATA;
     TxHeader.StdId = 0x123;
     TxHeader.TransmitGlobalTime = DISABLE;
+
+    HAL_CAN_Start(&hcan);
+    HAL_CAN_ActivateNotification(&hcan, CAN_IT_RX_FIFO0_MSG_PENDING);
+    InitCANSemaphore();
 }
 
 /**


### PR DESCRIPTION
Implemented CAN task by configuring it to send structs as messages through the bus.
- Implements the proper RX port callback to receive data and set a flag to unlock the main task
- Moved the bus initialization to the task initialization, as commented in *Added interrupt support #2* of **robotConfig**
